### PR TITLE
Upgrade Node.js to v10.x on Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
       pkg-config
 
 # add node 9.x repo
-RUN curl -sL https://deb.nodesource.com/setup_9.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 
 # add yarn repo
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -


### PR DESCRIPTION
The Node.js v9.x was causing the build to fail since it's incompatible
with `get-caller-file` library. The expected versions are "6.* || 8.*
|| >= 10.*.