### PR TITLE
devices: Fix modbus thing creation

### DIFF
--- a/app/controllers/devices.js
+++ b/app/controllers/devices.js
@@ -1,3 +1,4 @@
+var gateway = require('../models/gateway');
 var devicesService = require('../services/devices').devicesService;
 
 var list = function list(req, res, next) {
@@ -72,12 +73,19 @@ var update = function update(req, res, next) {
 
 var create = function create(req, res, next) {
   var device = req.body;
-  devicesService.create(device, function onCreate(devicesErr) {
-    if (devicesErr) {
-      next(devicesErr);
-    } else {
-      res.end();
+  gateway.getGatewaySettings(function onGatewaySettings(getGatewaySettingsErr, settings) {
+    if (getGatewaySettingsErr) {
+      next(getGatewaySettingsErr);
+      return;
     }
+    device.token = settings.token;
+    devicesService.create(device, function onCreate(devicesErr) {
+      if (devicesErr) {
+        next(devicesErr);
+      } else {
+        res.end();
+      }
+    });
   });
 };
 

--- a/app/services/devices.js
+++ b/app/services/devices.js
@@ -440,13 +440,14 @@ DevicesService.prototype.create = function create(device, done) {
 DevicesService.prototype.getDeviceConfig = function getDeviceConfig(device) {
   var deviceConfig = {
     KNoTThing: {
+      UserToken: device.token,
       Name: device.thingd.name,
       ModbusSlaveId: device.thingd.modbusSlaveID,
       ModbusURL: device.thingd.modbusSlaveURL
     }
   };
 
-  device.thingd.dataItems.forEach(function (value, index) {
+  device.thingd.dataItems.forEach(function onDataItem(value, index) {
     var item = 'DataItem_' + index;
     deviceConfig[item] = {
       SchemaSensorId: value.schema.sensorID,


### PR DESCRIPTION
**Describe what this PR introduces:**
 This patch adds the `UserToken` value to the thingd configuration file so that it can start correctly. In this case, the token passed is the KNoT Fog one, which is stored in the gateway settings.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bug fix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce any breaking changes?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] Related issues are referenced in the PR (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

**Testing environment:**

- Operating System/Platform: macOS Darwin - 18.0.0
- Node version: 6.14.4
- NPM version: v12.16.2