### PR TITLE
system: Add command to restart thingd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,8 @@ RUN npm_config_tmp=/tmp TMP=/tmp yarn
 # install configuration files
 RUN mkdir -p /etc/knot
 COPY ./config/gatewayConfig.json ./config/keys.json /etc/knot/
+COPY ./docker/thingd/start.sh ./docker/thingd/stop.sh /etc/knot/
+RUN chmod +x /etc/knot/start.sh /etc/knot/stop.sh
 RUN mkdir -p /usr/local/bin/knot-fog-source && touch /usr/local/bin/knot-fog-source/.env
 RUN mkdir -p /usr/local/bin/knot-fog-connector && mkdir -p /usr/local/bin/knot-fog-connector/config
 COPY ./docker/knot-fog-connector/config.json /usr/local/bin/knot-fog-connector/config/default.json

--- a/app/controllers/devices.js
+++ b/app/controllers/devices.js
@@ -1,5 +1,6 @@
 var gateway = require('../models/gateway');
 var devicesService = require('../services/devices').devicesService;
+var SystemService = require('../services/system').SystemService;
 
 var list = function list(req, res, next) {
   devicesService.list(function onDevicesReturned(listErr, devices) {
@@ -80,11 +81,18 @@ var create = function create(req, res, next) {
     }
     device.token = settings.token;
     devicesService.create(device, function onCreate(devicesErr) {
+      var systemSvc = new SystemService();
       if (devicesErr) {
         next(devicesErr);
-      } else {
-        res.end();
+        return;
       }
+      systemSvc.restartThingd(function onThingdRestarted(restartThingdErr) {
+        if (restartThingdErr) {
+          next(restartThingdErr);
+          return;
+        }
+        res.end();
+      });
     });
   });
 };

--- a/app/services/system.js
+++ b/app/services/system.js
@@ -22,6 +22,11 @@ SystemService.prototype.reboot = function reboot(done) {
   exec('reboot', done);
 };
 
+SystemService.prototype.restartThingd = function reboot(done) {
+  var command = '/etc/knot/stop.sh thingd && /etc/knot/start.sh thingd -n';
+  exec(command, done);
+};
+
 var logError = function logError(err) { // eslint-disable-line vars-on-top
   logger.warn('Error communicating with gateway control service');
   logger.debug(util.inspect(err));

--- a/docker/thingd/start.sh
+++ b/docker/thingd/start.sh
@@ -1,0 +1,1 @@
+echo "starting daemon..."

--- a/docker/thingd/stop.sh
+++ b/docker/thingd/stop.sh
@@ -1,0 +1,1 @@
+echo "stopping daemon..."


### PR DESCRIPTION
**Describe what this PR introduces:** 

After creating a new virtual thingd (Modbus), it's necessary to restart the daemon so that it can start with the new configuration and connect to the Fog/Cloud correctly.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bug fix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce any breaking changes?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] Related issues are referenced in the PR (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

**Testing environment:**

- Operating System/Platform: macOS Darwin - 18.0.0
- Node version: 6.14.4
- NPM version: v12.16.2