### PR TITLE
devices: Use sensorId to fill data items

### DIFF
--- a/app/services/devices.js
+++ b/app/services/devices.js
@@ -447,8 +447,8 @@ DevicesService.prototype.getDeviceConfig = function getDeviceConfig(device) {
     }
   };
 
-  device.thingd.dataItems.forEach(function onDataItem(value, index) {
-    var item = 'DataItem_' + index;
+  device.thingd.dataItems.forEach(function onDataItem(value) {
+    var item = 'DataItem_' + value.schema.sensorID;
     deviceConfig[item] = {
       SchemaSensorId: value.schema.sensorID,
       SchemaSensorName: value.schema.sensorName,


### PR DESCRIPTION
**Describe what this PR introduces:**

This PR fixes the thingd `device.conf` filling to pass the `sensorId` to identify a data item block instead of using the `forEach` index. This will avoid the values being different if the sensors don't start with id 0.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bug fix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce any breaking changes?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications: